### PR TITLE
StudyGroup에 이미지 필드랑 태그 필드 추가 특정 스터디 조회 api 

### DIFF
--- a/prisma/migrations/20241217055450_add_img_and_tag/migration.sql
+++ b/prisma/migrations/20241217055450_add_img_and_tag/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "StudyGroup" ADD COLUMN     "img" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,12 +14,14 @@ datasource db {
 }
 
 model StudyGroup {
-  id String @id @default(uuid())
-  nickname String
-  studyname String
+  id          String   @id @default(uuid())
+  nickname    String
+  studyname   String
   description String
-  password String
-  point Int @default(0)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  password    String
+  point       Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  img         String[] @default([])
+  tags        String[] @default([])
 }

--- a/server.js
+++ b/server.js
@@ -89,6 +89,20 @@ app.get(
   })
 );
 
+// 특정 스터디 조회 api  ,
+app.get(
+  "/study/:id",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+
+    const study = await prisma.studyGroup.findUniqueOrThrow({
+      where: { id },
+    });
+
+    res.send(study);
+  })
+);
+
 app.listen(process.env.PORT || 3001, () => {
   console.log(`Server started`);
 });


### PR DESCRIPTION
StudyGroup에 img와 tag 필드 추가 
default로 빈배열을 설정했습니다.

특정 스터디를 조회하는 라우터 추가